### PR TITLE
fix/floating-error-msg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .DS_STORE
 *.log
 
+.vscode
+
 node_modules
 dist/*
 

--- a/src/inputs/currency-input.jsx
+++ b/src/inputs/currency-input.jsx
@@ -65,8 +65,8 @@ class CurrencyInput extends React.Component {
           { currency ?
             <div className='Input-after'>{ currency }</div>
             : '' }
+          { err ? <ErrorTip contents={ err } /> : '' }
         </label>
-        { err ? <ErrorTip contents={ err } /> : '' }
       </div>
     )
   }


### PR DESCRIPTION
Make currency input messages relative to their immediate container.  See issue below:

<img width="321" alt="screen shot 2018-01-24 at 3 29 31 pm" src="https://user-images.githubusercontent.com/2547722/35360578-6d851286-011b-11e8-9264-70ebbe0b7c14.png">
